### PR TITLE
[week4] 전력망을 둘로 나누기

### DIFF
--- a/week4/전력망.java
+++ b/week4/전력망.java
@@ -1,0 +1,45 @@
+import java.util.*;
+
+class Solution {
+    int N;
+    public int solution(int n, int[][] wires) {
+        int answer = n;
+        N = n;
+        Arrays.sort(wires, (w1, w2) -> w1[0] - w2[0]);
+        for (int i = 0; i < n - 1; i++) {
+            int[][] cutNet = new int[n - 2][2];
+            int idx = 0;
+            for (int j = 0; j < n - 1; j++) {
+                if (i != j)
+                    cutNet[idx++] = wires[j];
+            }
+            
+            int net1 = counter(wires[i][0], cutNet);
+            int net2 = counter(wires[i][1], cutNet);
+            answer = Math.min(answer, Math.abs(net1 - net2));
+        }
+        return answer;
+    }
+    
+    public int counter(int first, int[][] wires) {
+        Queue<Integer> q = new LinkedList<>();
+        q.add(first);
+        boolean[] visited = new boolean[N + 1];
+        visited[first] = true;
+        int cnt = 1;
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            for (int[] wire: wires) {
+                if (wire[0] != cur && wire[1] != cur)
+                    continue;
+                int other = cur == wire[0] ? wire[1] : wire[0];
+                if (visited[other])
+                    continue;
+                visited[other] = true;
+                q.add(other);
+                cnt++;
+            }
+        }
+        return cnt;
+    }
+}


### PR DESCRIPTION
# 전력망을 둘로 나누기

[문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/86971)

## **소요 시간**
약 40분

## **풀이**
wires에서 하나를 자른(뺀) cutNet에서 자른 단면을 진입점으로 bfs 돌려서 크기를 구했다. 

## **핵심 로직**
```java
import java.util.*;

class Solution {
    int N;
    public int solution(int n, int[][] wires) {
        int answer = n;
        N = n;
        Arrays.sort(wires, (w1, w2) -> w1[0] - w2[0]);
        for (int i = 0; i < n - 1; i++) {
            int[][] cutNet = new int[n - 2][2];
            int idx = 0;
            for (int j = 0; j < n - 1; j++) {
                if (i != j)
                    cutNet[idx++] = wires[j];
            }
            
            int net1 = counter(wires[i][0], cutNet);
            int net2 = counter(wires[i][1], cutNet);
            answer = Math.min(answer, Math.abs(net1 - net2));
        }
        return answer;
    }
    
    public int counter(int first, int[][] wires) {
        Queue<Integer> q = new LinkedList<>();
        q.add(first);
        boolean[] visited = new boolean[N + 1];
        visited[first] = true;
        int cnt = 1;
        while (!q.isEmpty()) {
            int cur = q.poll();
            for (int[] wire: wires) {
                if (wire[0] != cur && wire[1] != cur)
                    continue;
                int other = cur == wire[0] ? wire[1] : wire[0];
                if (visited[other])
                    continue;
                visited[other] = true;
                q.add(other);
                cnt++;
            }
        }
        return cnt;
    }
}

```

## **고민한 부분**
처음에 버그가 있었는데 cutNet을 복사할때 참조복사가 돼서 발생한 문제였다.

---

## **시간 복잡도**

- **최선의 경우**: $O(n^2)$
- **평균**: $O(n^2)$
- **최악의 경우**: $O(n^2)$
