### PR TITLE
[week8] 가장 먼 노드

### DIFF
--- a/week8/가장먼노드.java
+++ b/week8/가장먼노드.java
@@ -1,0 +1,46 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int n, int[][] edge) {
+        List<List<Integer>> graph = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+        
+        for (int[] e: edge) {
+            int a = e[0];
+            int b = e[1];
+            graph.get(a).add(b);
+            graph.get(b).add(a);
+        }
+        
+        Queue<Integer> q = new LinkedList<>();
+        int[] dist = new int[n + 1]; // 1번 노드로부터 각 노드까지의 거리
+        Arrays.fill(dist, -1);
+        
+        q.add(1);
+        dist[1] = 0;
+        int maxDist = 0;
+        
+        while (!q.isEmpty()) {
+            int cur = q.poll();
+            
+            for (int next: graph.get(cur)) {
+                if (dist[next] == -1) {
+                    dist[next] = dist[cur] + 1;
+                    maxDist = Math.max(maxDist, dist[next]);
+                    q.add(next);
+                }
+            }
+        }
+        
+        int cnt = 0;
+        
+        for (int i = 1; i <= n; i++) {
+            if (dist[i] == maxDist)
+                cnt++;
+        }
+        
+        return cnt;
+    }
+}


### PR DESCRIPTION
# 가장 먼 노드

[문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/49189)

## **소요 시간**
약 1시간

## **풀이**
노드들의 연결 정보를 인접 리스트에 담아 bfs를 돌린다. 
1번 노드부터 시작해 1번 노드와 연결된 노드들을 순차적으로 방문하면서 
거리를 저장한다. 
이 후 가장 큰 거리의 값을 가지는 노드의 개수를 세서 리턴한다. 

## **핵심 로직**
```java
import java.util.*;

class Solution {
    public int solution(int n, int[][] edge) {
        List<List<Integer>> graph = new ArrayList<>();
        for (int i = 0; i <= n; i++) {
            graph.add(new ArrayList<>());
        }
        
        for (int[] e: edge) {
            int a = e[0];
            int b = e[1];
            graph.get(a).add(b);
            graph.get(b).add(a);
        }
        
        Queue<Integer> q = new LinkedList<>();
        int[] dist = new int[n + 1]; // 1번 노드로부터 각 노드까지의 거리
        Arrays.fill(dist, -1);
        
        q.add(1);
        dist[1] = 0;
        int maxDist = 0;
        
        while (!q.isEmpty()) {
            int cur = q.poll();
            
            for (int next: graph.get(cur)) {
                if (dist[next] == -1) {
                    dist[next] = dist[cur] + 1;
                    maxDist = Math.max(maxDist, dist[next]);
                    q.add(next);
                }
            }
        }
        
        int cnt = 0;
        
        for (int i = 1; i <= n; i++) {
            if (dist[i] == maxDist)
                cnt++;
        }
        
        return cnt;
    }
}

```

## **고민한 부분**
그래프 문제는 거의 안 풀어봐서 어떻게 푸는게 정석인지 알아봤다. 
그래프의 연결 관계를 나타낼 때 인접 리스트 방식과 인접 행렬 방식이 있었다. 
두 방식은 담는 자료구조에 따라 시간복잡도와 공간복잡도 면에서 차이가 
문제에 따라 잘 고르면 된다. 
해당 문제에선 특정 노드에 연결된 모든 노드를 방문하는 일이 많기 때문에 
인접 리스트 방식으로 관리하는게 더 이점이 있다. 

---

## **시간 복잡도**

- **최선의 경우**: $O(N + E)$
- **평균**: $O(N + E)$
- **최악의 경우**: $O(N + E)$
